### PR TITLE
Use rerender for highlight updates test

### DIFF
--- a/src/PianoBase/PianoBase.test.tsx
+++ b/src/PianoBase/PianoBase.test.tsx
@@ -231,10 +231,11 @@ describe('PianoBase', () => {
     });
 
     it('updates highlights when highlightOnThePiano prop changes', () => {
-      render(<PianoBase highlightOnThePiano={['C4', 'E4', 'G4']} />);
+      const { rerender } = render(
+        <PianoBase highlightOnThePiano={['C4', 'E4', 'G4']} />
+      );
       jest.clearAllMocks();
       const newChord: tNoteWithOctave[] = ['D4', 'F#4', 'A4'];
-      const { rerender } = render(<PianoBase />);
       rerender(<PianoBase highlightOnThePiano={newChord} />);
 
       expect(mockHighlightFns.clearGroupHighlights).toHaveBeenCalledWith(0);


### PR DESCRIPTION
## Summary
- simplify highlight update test by capturing `rerender`

## Testing
- `npx jest`


------
https://chatgpt.com/codex/tasks/task_e_688adb5573e08332b6d1fe1bc9cd5652