### PR TITLE
refactor(mode-table): dynamic row backgrounds

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,15 +77,6 @@ function App() {
             activeMode={activeMode}
           />
           <br />
-
-          {/* 
-          <h1>starting with Ionian:</h1>
-          <h1>naturalMajorScale: {naturalMajorScale.join(" ")}</h1>
-          <h1>activeMode: {activeMode}</h1>
-          <h1>diatonicModeScale: {diatonicModeScale.join(" ")}</h1>
-          <h1>humanReadableScale: {humanReadableScale.join(" ")}</h1>
-          <h1>octaveAssignedScale: {octaveAssignedScale.join(" ")}</h1>
-          <h1>pianoScale: {pianoScale.join(" ")}</h1> */}
           {debug && (
             <>
               <h1>starting with Ionian:</h1>
@@ -114,6 +105,8 @@ function App() {
         style={{ background: scaleGradientColor, borderRadius: 16 }}
       >
         <PianoBase
+          octave={5}
+          octaves={2}
           highlightOnThePiano={pianoScale}
           createSynth={createPianoSynth}
           alwaysShowNoteNames

--- a/src/ModeTable/ModeBreakdown.css
+++ b/src/ModeTable/ModeBreakdown.css
@@ -1,12 +1,8 @@
 table.mode-breakdown {
-  border-collapse: collapse;
-  width: 100%;
   margin: 10px 0;
-  tr {
-    td {
-      border: 0;
-    }
-  }
+ td {
+  width: 50px;
+ }
 }
 
 .mode-breakdown__heading {

--- a/src/ModeTable/ModeBreakdown.tsx
+++ b/src/ModeTable/ModeBreakdown.tsx
@@ -61,14 +61,6 @@ const ModeBreakdown: React.FC<ModeBreakdownProps> = ({
             Escala Natural Mayor "{tonic}"
           </td>
         </tr>
-        <IntervalRow pattern={MODE_INTERVAL_PATTERNS['ionian']} />
-        <tr>
-          {DEGREES.map((deg) => (
-            <td key={deg} className="mode-breakdown__degree-cell">
-              {deg}
-            </td>
-          ))}
-        </tr>
         <tr>
           {naturalMajorScale.map((note, i) => (
             <td key={i} className="mode-breakdown__note-cell">
@@ -77,25 +69,17 @@ const ModeBreakdown: React.FC<ModeBreakdownProps> = ({
           ))}
         </tr>
         <tr>
+          {DEGREES.map((deg) => (
+            <td key={deg} className="mode-breakdown__degree-cell">
+              {deg}
+            </td>
+          ))}
+        </tr>
+        <IntervalRow pattern={MODE_INTERVAL_PATTERNS['ionian']} />
+        <tr>
           <td colSpan={7} className="mode-breakdown__heading">
             Escala en "Modo {activeMode}"
           </td>
-        </tr>
-        <IntervalRow pattern={MODE_INTERVAL_PATTERNS[activeMode]} />
-        <tr>
-          {DEGREES.map((deg, i) => {
-            const alt = MODE_ALTERATIONS[activeMode].find(a => a.degree === i + 1);
-            const text = deg + (alt?.alteration || '');
-            const Tag = alt ? 'strong' : 'span';
-            return (
-              <td key={deg} className={"mode-breakdown__degree-cell" +
-                (alt ? " mode-breakdown__degree-cell--altered" : "")
-              }
-              >
-                <Tag>{text}</Tag>
-              </td>
-            );
-          })}
         </tr>
         <tr>
           {diatonicModeScale.map((note, i) => {
@@ -112,6 +96,22 @@ const ModeBreakdown: React.FC<ModeBreakdownProps> = ({
             );
           })}
         </tr>
+        <tr>
+          {DEGREES.map((deg, i) => {
+            const alt = MODE_ALTERATIONS[activeMode].find(a => a.degree === i + 1);
+            const text = deg + (alt?.alteration || '');
+            const Tag = alt ? 'strong' : 'span';
+            return (
+              <td key={deg} className={"mode-breakdown__degree-cell" +
+                (alt ? " mode-breakdown__degree-cell--altered" : "")
+              }
+              >
+                <Tag>{text}</Tag>
+              </td>
+            );
+          })}
+        </tr>
+        <IntervalRow pattern={MODE_INTERVAL_PATTERNS[activeMode]} />
       </tbody>
     </table>
   );

--- a/src/ModeTable/ModeBreakdown.tsx
+++ b/src/ModeTable/ModeBreakdown.tsx
@@ -58,7 +58,7 @@ const ModeBreakdown: React.FC<ModeBreakdownProps> = ({
       <tbody>
         <tr>
           <td colSpan={7} className="mode-breakdown__heading">
-            Escala mayor de {tonic}
+            Escala Natural Mayor "{tonic}"
           </td>
         </tr>
         <IntervalRow pattern={MODE_INTERVAL_PATTERNS['ionian']} />
@@ -78,7 +78,7 @@ const ModeBreakdown: React.FC<ModeBreakdownProps> = ({
         </tr>
         <tr>
           <td colSpan={7} className="mode-breakdown__heading">
-            Escala mayor de {tonic} (modo {activeMode})
+            Escala en "Modo {activeMode}"
           </td>
         </tr>
         <IntervalRow pattern={MODE_INTERVAL_PATTERNS[activeMode]} />

--- a/src/ModeTable/ModeTable.css
+++ b/src/ModeTable/ModeTable.css
@@ -2,52 +2,49 @@
   white-space: nowrap;
 }
 
-.mode-row.mode-ionian {
-  background-color: #fff9a9; 
-}
-
-.mode-row.mode-dorian {
-  background-color: #cce6ff; 
-}
-
-.mode-row.mode-phrygian {
-  background-color: #d3a2b6; 
-}
-
-.mode-row.mode-lydian {
-  background-color: #a2b6d3; 
-}
-
-.mode-row.mode-mixolydian {
-  background-color: #ffb3b3; 
-}
-
-.mode-row.mode-aeolian {
-  background-color: #a2e6e6; 
-}
-
-.mode-row.mode-locrian {
-  background-color: #d39ca2; 
+button {
+  border: none;
+  border-radius: 7px;
+  padding: 0.5em 1.3em;
+  font-size: 1.05em;
+  font-family: inherit;
+  font-weight: 600;
+  box-shadow:
+    0 2px 6px 0 #0002,
+    0 1.5px 0 #0001 inset,
+    0 0.5px 0 #fff8 inset;
+  cursor: pointer;
 }
 
 button.active,
 button[aria-pressed="true"] {
-  background: #4f46e5;
-  color: #fff;
-  font-weight: bold;
-  border-radius: 4px;
-  border: 1px solid #2d2d2d;
-  box-shadow: 0 1px 3px #0002;
+  border: 3px solid #fff;
+  box-shadow:
+    0 0 0 3.5px #000b,      /* Sombra negra alrededor */
+    0 0 0 7px #ffe06b88,    /* Halo amarillo transparente */
+    0 4px 14px #0002,       /* Sombra suave inferior */
+    0 1.5px 0 #fff3 inset,
+    0 0.5px 0 #0004 inset;
+  z-index: 1;
+  position: relative;
 }
 
-button:not(.active) {
-  background: #f4f4f4;
-  color: #222;
-  border-radius: 4px;
-  border: 1px solid #bbb;
+button:not(.active):hover,
+button:not([aria-pressed="true"]):hover {
+  background: linear-gradient(180deg, #eef 70%, #c8d2fa 100%);
+  box-shadow:
+    0 6px 18px 0 #4460ce30,
+    0 1.5px 0 #fff8 inset,
+    0 0.5px 0 #0003 inset;
+  color: #191970;
+  transform: translateY(-1px) scale(1.03);
 }
 
-strong {
-  color: #8f00ff;
-  font-weight: bold;
+button:active {
+  filter: brightness(0.97);
+  transform: translateY(2px) scale(0.98);
+  box-shadow:
+    0 2px 6px 0 #0002,
+    0 1.5px 0 #fff2 inset,
+    0 0.5px 0 #0002 inset;
 }

--- a/src/ModeTable/ModeTable.tsx
+++ b/src/ModeTable/ModeTable.tsx
@@ -1,11 +1,13 @@
 import React, { ReactNode } from 'react';
-import type { tMode, tScale } from './../PianoBase/PianoBase.types';
+import type { tMode, tScale, tChordQualities, tNoteWithOctave } from './../PianoBase/PianoBase.types';
 import {
   MODE_ALTERATIONS,
   MODE_INTERVAL_PATTERNS,
   DEGREES,
 } from '../PianoBase/PianoBase.types';
 import { getDiatonicScale } from '../utils/getDiatonicScale';
+import { getChordColor } from './../ChordPalette/ChordPalette.utils';
+import { normalizeToPianoSharpScale } from './../utils/normalizeToPianoSharpScale';
 import './ModeTable.css';
 
 export interface ModeTableProps {
@@ -19,17 +21,18 @@ export type ModeDefinition = {
   mode: tMode;
   description: string;
   modernEquivalent: string;
-  classicalType: string;
+  classicalType: tChordQualities;
+  color: string;
 };
 
 const modes: ModeDefinition[] = [
-  { name: "Ionian", mode: "ionian", description: "Escala mayor natural, base tonal.", modernEquivalent: "Mayor", classicalType: "Maj" },
-  { name: "Dorian", mode: "dorian", description: "Menor con 6ta mayor brillante.", modernEquivalent: "Menor Dorian", classicalType: "min" },
-  { name: "Phrygian", mode: "phrygian", description: "Menor exótico, 2da menor tensa.", modernEquivalent: "Menor Frigia", classicalType: "min" },
-  { name: "Lydian", mode: "lydian", description: "Mayor soñador, 4ta aumentada.", modernEquivalent: "Mayor Lidia", classicalType: "Maj" },
-  { name: "Mixolydian", mode: "mixolydian", description: "Mayor bluesy, 7ma menor.", modernEquivalent: "Mayor Mixolidia", classicalType: "Maj" },
-  { name: "Aeolian", mode: "aeolian", description: "Menor natural, base melancólica.", modernEquivalent: "Menor natural", classicalType: "min" },
-  { name: "Locrian", mode: "locrian", description: "Semidisminuido, 2da menor, 5ta b.", modernEquivalent: "Semi-disminuida", classicalType: "dim" },
+  { name: "Ionian", mode: "ionian", description: "Escala mayor natural, base tonal.", modernEquivalent: "Mayor", classicalType: "maj", color: '#e74c3c' },
+  { name: "Dorian", mode: "dorian", description: "Menor con 6ta mayor brillante.", modernEquivalent: "Menor Dorian", classicalType: "min", color: '#e67e22' },
+  { name: "Phrygian", mode: "phrygian", description: "Menor exótico, 2da menor tensa.", modernEquivalent: "Menor Frigia", classicalType: "min", color: '#f1c40f' },
+  { name: "Lydian", mode: "lydian", description: "Mayor soñador, 4ta aumentada.", modernEquivalent: "Mayor Lidia", classicalType: "maj", color: '#2ecc71' },
+  { name: "Mixolydian", mode: "mixolydian", description: "Mayor bluesy, 7ma menor.", modernEquivalent: "Mayor Mixolidia", classicalType: "maj", color: '#3498db' },
+  { name: "Aeolian", mode: "aeolian", description: "Menor natural, base melancólica.", modernEquivalent: "Menor natural", classicalType: "min", color: '#273c75' },
+  { name: "Locrian", mode: "locrian", description: "Semidisminuido, 2da menor, 5ta b.", modernEquivalent: "Semi-disminuida", classicalType: "dim", color: '#9b59b6' },
 ];
 
 function withSeparator(nodes: ReactNode[], sep: ReactNode): ReactNode[] {
@@ -50,8 +53,8 @@ const ModeTable: React.FC<ModeTableProps> = ({ scale, onModeClick, activeMode })
         <tr>
           <th>Tipo clásico</th>
           <th>Modo</th>
-          <th>Grados</th>
           <th>Notas</th>
+          <th>Grados</th>
           <th>Intervalos</th>
           <th>Equivalencia moderna</th>
           <th>Descripción</th>
@@ -59,12 +62,14 @@ const ModeTable: React.FC<ModeTableProps> = ({ scale, onModeClick, activeMode })
       </thead>
       <tbody>
         {modes.map((mode) => {
-          // Obtiene la escala diatónica teórica para la tónica y el modo
           const diatonicScale = getDiatonicScale(scale[0], MODE_INTERVAL_PATTERNS[mode.mode]);
+          const normalizedTonic = normalizeToPianoSharpScale([scale[0]])[0];
+          const rowBackground = getChordColor(normalizedTonic, mode.classicalType, [normalizedTonic as tNoteWithOctave]);
           return (
             <tr
               key={mode.name}
-              className={`mode-row mode-${mode.mode}${mode.mode === activeMode ? ' selected' : ''}`}
+              className={`mode-row`}
+              style={{ background: rowBackground }}
             >
               <td>{mode.classicalType}</td>
               <td>
@@ -72,19 +77,16 @@ const ModeTable: React.FC<ModeTableProps> = ({ scale, onModeClick, activeMode })
                   onClick={() => onModeClick(mode.mode)}
                   aria-pressed={mode.mode === activeMode}
                   className={mode.mode === activeMode ? 'active' : ''}
+                  style={{
+                    backgroundColor: mode.color,
+                    color: 'white',
+                    fontWeight: mode.mode === activeMode ? 'bold' : undefined,
+                  }}
                 >
                   {mode.name}
                 </button>
               </td>
-              
-              <td>{withSeparator(DEGREES.map((deg, i) => {
-                // buscamos si este grado lleva alteración
-                const alt = MODE_ALTERATIONS[mode.mode].find(a => a.degree === i + 1);
-                const text = deg + (alt?.alteration || '');     // p.e. "III" o "IIIb"
-                const Tag = alt ? 'strong' : 'span';           // si hay alteración, <strong>, si no <span>
-                return <Tag key={deg}>{text}</Tag>;
-              }), ' - ')}</td>
-              <td>
+               <td>
                 {withSeparator(
                   diatonicScale.map((note, i) => {
                     const isAltered = MODE_ALTERATIONS[mode.mode].some(a => a.degree === i + 1);
@@ -94,6 +96,14 @@ const ModeTable: React.FC<ModeTableProps> = ({ scale, onModeClick, activeMode })
                   ', '
                 )}
               </td>
+              <td>{withSeparator(DEGREES.map((deg, i) => {
+                // buscamos si este grado lleva alteración
+                const alt = MODE_ALTERATIONS[mode.mode].find(a => a.degree === i + 1);
+                const text = deg + (alt?.alteration || '');
+                const Tag = alt ? 'strong' : 'span';
+                return <Tag key={deg}>{text}</Tag>;
+              }), ' - ')}</td>
+             
               <td>{MODE_INTERVAL_PATTERNS[mode.mode].join("-")}</td>
               <td>{mode.modernEquivalent}</td>
               <td>{mode.description}</td>


### PR DESCRIPTION
closes https://github.com/vyk2rr/piano-music-modes/issues/10

- Remove static CSS classes for mode rows
- Normalize tonic using normalizeToPianoSharpScale
- Apply getChordColor to each <tr> background
- Preserve button color via mode.color
- Clean debug code from App.tsx
- Set octave and octaves props on PianoBase