### PR TITLE
Improve visibility of tonic selector and intro text

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -1,0 +1,6 @@
+.intro {
+  font-size: 2rem;
+  margin: 24px 0;
+  color: #333;
+  line-height: 1;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { getDiatonicScale } from './utils/getDiatonicScale';
 import { getChordColor } from './ChordPalette/ChordPalette.utils';
 import createPianoSynth from './utils/createPianoSynth';
 import TonicSelector from './TonicSelector/TonicSelector';
+import styles from './App.module.css';
 import ModeTable from './ModeTable/ModeTable';
 import PianoBase from './PianoBase/PianoBase';
 import normalizeToSharp from './utils/normalizeToSharp';
@@ -64,8 +65,9 @@ function App() {
 
   return (
     <div>
-      <p>
-        Elige una tónica y un modo para explorar cómo suenan y cómo se construyen las escalas musicales
+      <p className={styles.intro}>
+        Elige una tónica y un modo para explorar cómo suenan 
+        y cómo se construyen las escalas musicales:
       </p>
       <TonicSelector tonic={tonic} onChange={handleTonicChange} />
       {tonic ? (

--- a/src/TonicSelector/TonicSelector.module.css
+++ b/src/TonicSelector/TonicSelector.module.css
@@ -1,0 +1,23 @@
+.selector {
+  font-size: 1.5rem;
+  padding: 14px 20px;
+  border-radius: 12px;
+  border: 2px solid #666;
+  background: #fff;
+  color: #222;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+  display: block;
+  max-width: 320px;
+  transition: all 0.2s ease;
+}
+
+.selector:hover {
+  border-color: #a34;
+  box-shadow: 0 6px 16px rgba(163, 52, 52, 0.2);
+}
+
+.selector:focus {
+  outline: none;
+  border-color: #a34;
+  box-shadow: 0 0 0 3px rgba(163, 52, 52, 0.3);
+}

--- a/src/TonicSelector/TonicSelector.tsx
+++ b/src/TonicSelector/TonicSelector.tsx
@@ -1,4 +1,5 @@
 import { BASE_NOTES, NOTES, tNoteName, tNote } from '../PianoBase/PianoBase.types';
+import styles from './TonicSelector.module.css'
 
 interface iTonicSelector {
   tonic: tNoteName | undefined;
@@ -8,6 +9,7 @@ interface iTonicSelector {
 export default function TonicSelector({ tonic, onChange }: iTonicSelector) {
   return (
     <select
+      className={styles.selector}
       data-testid="tonic-selector"
       value={tonic}
       onChange={e => onChange(e.target.value === "" ? undefined : (e.target.value as tNoteName))}


### PR DESCRIPTION
Quick UI enhancement: enlarged the tonic selector and styled the intro paragraph for better visibility and onboarding clarity. No logic changes.

### screenshot: 

<img width="570" height="405" alt="image" src="https://github.com/user-attachments/assets/d8cb8dbc-2bdf-4fc9-a333-a2149d725ff7" />
