### PR TITLE
New mini-piano visual and clearer modes table layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,7 +66,7 @@ function App() {
   return (
     <div>
       <p className={styles.intro}>
-        Elige una tónica y un modo para explorar cómo suenan 
+        Elige una tónica y un modo para explorar cómo suenan
         y cómo se construyen las escalas musicales:
       </p>
       <TonicSelector tonic={tonic} onChange={handleTonicChange} />
@@ -91,6 +91,19 @@ function App() {
             </>
           )}
 
+          <div
+            className="piano-container"
+            style={{ background: scaleGradientColor, borderRadius: 16 }}
+          >
+            <PianoBase
+              octave={5}
+              octaves={2}
+              highlightOnThePiano={pianoScale}
+              createSynth={createPianoSynth}
+              alwaysShowNoteNames
+            />
+          </div>
+
           <ModeBreakdown
             tonic={tonic}
             activeMode={activeMode}
@@ -102,18 +115,7 @@ function App() {
         </>
       ) : null}
 
-      <div
-        className="piano-container"
-        style={{ background: scaleGradientColor, borderRadius: 16 }}
-      >
-        <PianoBase
-          octave={5}
-          octaves={2}
-          highlightOnThePiano={pianoScale}
-          createSynth={createPianoSynth}
-          alwaysShowNoteNames
-        />
-      </div>
+
     </div>
   );
 }

--- a/src/MiniPianoSvg/MiniPianoSvg.test.tsx
+++ b/src/MiniPianoSvg/MiniPianoSvg.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import MiniPianoSvg from './MiniPianoSvg';
+import type { tNoteName } from '../PianoBase/PianoBase.types';
+
+describe('MiniPianoSvg', () => {
+  it('renderiza 7 teclas blancas', () => {
+    const { container } = render(<MiniPianoSvg />);
+    // Debe haber 7 rect blancos (fill="#fff")
+    const whiteKeys = container.querySelectorAll('rect[fill="#fff"]');
+    expect(whiteKeys.length).toBe(7);
+  });
+
+  it('resalta teclas blancas pasadas en highlight', () => {
+    const highlights: tNoteName[] = ['C', 'E'];
+    const { container } = render(<MiniPianoSvg highlight={highlights} />);
+    // Color de highlight de blanca: #ffd700
+    const highlighted = Array.from(container.querySelectorAll('rect')).filter(
+      rect => rect.getAttribute('fill') === '#ffd700'
+    );
+    expect(highlighted.length).toBe(2);
+  });
+
+  it('resalta teclas negras pasadas en highlight', () => {
+    const highlights: tNoteName[] = ['D#'];
+    const { container } = render(<MiniPianoSvg highlight={highlights} />);
+    // Color de highlight de negra: #ff8500
+    const highlighted = Array.from(container.querySelectorAll('rect')).filter(
+      rect => rect.getAttribute('fill') === '#ff8500'
+    );
+    expect(highlighted.length).toBe(1);
+  });
+
+  it('resalta todas blancas y negras', () => {
+    const highlights: tNoteName[] = ['C', 'D', 'E', 'F', 'G', 'A', 'B', 'C#', 'D#', 'F#', 'G#', 'A#'];
+    const { container } = render(<MiniPianoSvg highlight={highlights} />);
+    const whiteHighlighted = Array.from(container.querySelectorAll('rect')).filter(
+      rect => rect.getAttribute('fill') === '#ffd700'
+    );
+    const blackHighlighted = Array.from(container.querySelectorAll('rect')).filter(
+      rect => rect.getAttribute('fill') === '#ff8500'
+    );
+    expect(whiteHighlighted.length).toBe(7);
+    expect(blackHighlighted.length).toBe(5);
+  });
+
+  it('no resalta ninguna tecla si highlight es vacío', () => {
+    const { container } = render(<MiniPianoSvg highlight={[]} />);
+    const highlighted = Array.from(container.querySelectorAll('rect')).filter(
+      rect => rect.getAttribute('fill') === '#ffd700' || rect.getAttribute('fill') === '#ff8500'
+    );
+    expect(highlighted.length).toBe(0);
+  });
+
+  it('renderiza 12 teclas en total: 7 blancas y 5 negras', () => {
+    const { container } = render(<MiniPianoSvg />);
+    const whiteKeys = container.querySelectorAll('rect[fill="#fff"]');
+    const blackKeys = container.querySelectorAll('rect[fill="#000"]');
+    expect(whiteKeys.length).toBe(7);
+    expect(blackKeys.length).toBe(5);
+    expect(whiteKeys.length + blackKeys.length).toBe(12);
+  });
+});

--- a/src/MiniPianoSvg/MiniPianoSvg.tsx
+++ b/src/MiniPianoSvg/MiniPianoSvg.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import type { tNoteName } from '../PianoBase/PianoBase.types';
+
+// Blancas C–B
+const whiteNotes: tNoteName[] = ['C', 'D', 'E', 'F', 'G', 'A', 'B'];
+
+// Negras y su posición relativa en mini-piano
+const blackNotes = [
+  { note: 'C#' as tNoteName, pos: 1 },
+  { note: 'D#' as tNoteName, pos: 2 },
+  // No hay entre E–F
+  { note: 'F#' as tNoteName, pos: 4 },
+  { note: 'G#' as tNoteName, pos: 5 },
+  { note: 'A#' as tNoteName, pos: 6 }
+];
+
+interface MiniPianoSvgProps {
+  highlight?: tNoteName[]; // Ejemplo: ['C', 'D#', 'F']
+}
+
+const MiniPianoSvg: React.FC<MiniPianoSvgProps> = ({ highlight = [] }) => (
+  <svg width="70" height="25" viewBox="0 0 70 25" xmlns="http://www.w3.org/2000/svg">
+    {/* White keys */}
+    {whiteNotes.map((note, i) => (
+      <rect
+        key={`w-${i}`}
+        x={i * 10}
+        y={0}
+        width={10}
+        height={25}
+        fill={highlight.includes(note) ? '#ffd700' : '#fff'}
+        stroke="#000"
+        strokeWidth={0.5}
+      />
+    ))}
+    {/* Black keys */}
+    {blackNotes.map(({ note, pos }) => (
+      <rect
+        key={`b-${note}`}
+        x={pos * 10 - 3}
+        y={0}
+        width={6}
+        height={15}
+        fill={highlight.includes(note) ? '#ff8500' : '#000'}
+      />
+    ))}
+  </svg>
+);
+
+export default MiniPianoSvg;

--- a/src/ModeTable/ModeBreakdown.tsx
+++ b/src/ModeTable/ModeBreakdown.tsx
@@ -58,27 +58,7 @@ const ModeBreakdown: React.FC<ModeBreakdownProps> = ({
       <tbody>
         <tr>
           <td colSpan={7} className="mode-breakdown__heading">
-            Escala Natural Mayor "{tonic}"
-          </td>
-        </tr>
-        <tr>
-          {naturalMajorScale.map((note, i) => (
-            <td key={i} className="mode-breakdown__note-cell">
-              {note}
-            </td>
-          ))}
-        </tr>
-        <tr>
-          {DEGREES.map((deg) => (
-            <td key={deg} className="mode-breakdown__degree-cell">
-              {deg}
-            </td>
-          ))}
-        </tr>
-        <IntervalRow pattern={MODE_INTERVAL_PATTERNS['ionian']} />
-        <tr>
-          <td colSpan={7} className="mode-breakdown__heading">
-            Escala en "Modo {activeMode}"
+            "{tonic}" Modo {activeMode}
           </td>
         </tr>
         <tr>
@@ -112,6 +92,27 @@ const ModeBreakdown: React.FC<ModeBreakdownProps> = ({
           })}
         </tr>
         <IntervalRow pattern={MODE_INTERVAL_PATTERNS[activeMode]} />
+
+        <tr>
+          <td colSpan={7} className="mode-breakdown__heading">
+            "{tonic}" Mayor Natural 
+          </td>
+        </tr>
+        <tr>
+          {naturalMajorScale.map((note, i) => (
+            <td key={i} className="mode-breakdown__note-cell">
+              {note}
+            </td>
+          ))}
+        </tr>
+        <tr>
+          {DEGREES.map((deg) => (
+            <td key={deg} className="mode-breakdown__degree-cell">
+              {deg}
+            </td>
+          ))}
+        </tr>
+        <IntervalRow pattern={MODE_INTERVAL_PATTERNS['ionian']} />
       </tbody>
     </table>
   );

--- a/src/ModeTable/ModeTable.tsx
+++ b/src/ModeTable/ModeTable.tsx
@@ -8,6 +8,7 @@ import {
 import { getDiatonicScale } from '../utils/getDiatonicScale';
 import { getChordColor } from './../ChordPalette/ChordPalette.utils';
 import { normalizeToPianoSharpScale } from './../utils/normalizeToPianoSharpScale';
+import MiniPianoSvg from '../MiniPianoSvg/MiniPianoSvg';
 import './ModeTable.css';
 
 export interface ModeTableProps {
@@ -54,6 +55,7 @@ const ModeTable: React.FC<ModeTableProps> = ({ scale, onModeClick, activeMode })
           <th>Tipo clásico</th>
           <th>Modo</th>
           <th>Notas</th>
+          <th>Mini-Piano</th>
           <th>Grados</th>
           <th>Intervalos</th>
           <th>Equivalencia moderna</th>
@@ -86,7 +88,7 @@ const ModeTable: React.FC<ModeTableProps> = ({ scale, onModeClick, activeMode })
                   {mode.name}
                 </button>
               </td>
-               <td>
+              <td>
                 {withSeparator(
                   diatonicScale.map((note, i) => {
                     const isAltered = MODE_ALTERATIONS[mode.mode].some(a => a.degree === i + 1);
@@ -96,6 +98,12 @@ const ModeTable: React.FC<ModeTableProps> = ({ scale, onModeClick, activeMode })
                   ', '
                 )}
               </td>
+              <td>
+                {(() => {
+                  const normalized = normalizeToPianoSharpScale(diatonicScale);
+                  return <MiniPianoSvg highlight={normalized} />;
+                })()}
+              </td>
               <td>{withSeparator(DEGREES.map((deg, i) => {
                 // buscamos si este grado lleva alteración
                 const alt = MODE_ALTERATIONS[mode.mode].find(a => a.degree === i + 1);
@@ -103,7 +111,7 @@ const ModeTable: React.FC<ModeTableProps> = ({ scale, onModeClick, activeMode })
                 const Tag = alt ? 'strong' : 'span';
                 return <Tag key={deg}>{text}</Tag>;
               }), ' - ')}</td>
-             
+
               <td>{MODE_INTERVAL_PATTERNS[mode.mode].join("-")}</td>
               <td>{mode.modernEquivalent}</td>
               <td>{mode.description}</td>


### PR DESCRIPTION
This PR adds a mini piano graphic to the modes table so you can instantly see which keys belong to each scale.

The mode breakdown is also reorganized for easier side-by-side comparison with the natural major scale.

Navigation is clearer and understanding modes is now much more intuitive.
